### PR TITLE
Make version checking Yosemite compatible

### DIFF
--- a/Resources/bender
+++ b/Resources/bender
@@ -11,12 +11,13 @@
 # 2.0 - postgres backup for profilemanager added by Adrian Burgess
 # 2.1 - Added --version flag code.
 # https://gist.github.com/anotherspot/9145864
+# 2.2 - make macOS version checking Yosemite compatible.
  
 ################################## VARIABLE DEFINITIONS ################################# 
 #########################################################################################
  
 host=$(hostname)
-macOS=$(sw_vers | awk '/ProductVersion/{print substr($2,1,4)}' | tr -d ".")
+macOS=$(sw_vers | awk '/ProductVersion/{print substr($2,1,5)}' | tr -d ".")
 macSN=$(system_profiler SPHardwareDataType | awk '/Serial Number/{print $4}')
 date=$(date +%Y-%m-%d-%H%M)
 pass=$(system_profiler SPHardwareDataType | awk '/Hardware UUID/{print $3}')


### PR DESCRIPTION
Without this change the version reported in $macOS is 101 on Yosemite. This changes it to be 1010 and is backwards compatible back to 10.1. This too will break in the future (after version 10.99...) but that problem can be solved another day.
